### PR TITLE
:art: Design: PlayerList 일부 디자인 수정

### DIFF
--- a/src/components/LCK/components/Team/Player/Player.module.scss
+++ b/src/components/LCK/components/Team/Player/Player.module.scss
@@ -20,7 +20,7 @@
   font-family: 'Roboto', sans-serif;
   display: flex;
   width: 100%;
-  height: 400px;
+  height: 350px;
   position: relative;
   border-radius: 10px;
   border: 1px solid var(--tab-border-color);
@@ -65,8 +65,8 @@
         position: absolute;
         left: 0;
         bottom: 0;
-        width: 250px;
-        height: 200px;
+        width: 15em;
+        height: 13em;
         opacity: 1;
         z-index: 9998;
       }

--- a/src/components/LCK/components/Team/PlayerList/List.module.scss
+++ b/src/components/LCK/components/Team/PlayerList/List.module.scss
@@ -32,10 +32,10 @@
     display: grid;
     gap: 5px;
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    grid-template-rows: repeat(1, minmax(auto-fit, 1fr));
+    grid-template-rows: repeat(auto-fit, minmax(300px, 1fr));
     .card {
       width: 100%;
-      height: 300px;
+      height: 100%;
       border-radius: 10px;
     }
   }

--- a/src/components/LCK/components/Team/PlayerList/PlayerList.module.scss
+++ b/src/components/LCK/components/Team/PlayerList/PlayerList.module.scss
@@ -11,7 +11,7 @@
     display: flex;
     justify-content: center;
     .list {
-      width: 80%;
+      width: 90%;
       height: 100%;
     }
   }

--- a/src/components/LCK/components/Team/TeamSlide/responsive.module.scss
+++ b/src/components/LCK/components/Team/TeamSlide/responsive.module.scss
@@ -2,14 +2,15 @@
   @media only screen and (min-width: 300px) and (max-width: 800px) {
     .slider_container {
       display: flex;
+      align-items: center;
       .wrapper {
         width: 100%;
+        height: 100%;
         padding: 3px;
         .team_slide {
           width: 100%;
           display: flex;
           flex-direction: row;
-          padding: 10px 0;
           .team_logo {
             padding: 5px;
             cursor: pointer;


### PR DESCRIPTION
센터 안맞고, 선수 정보카드 겹치는 현상이 있어서 수정

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가 및 수정
- [x] 디자인 추가 및 수정
- [ ] 문서 추가 및 수정
- [ ] 버그 수정 및 삭제
- [ ] 파일 및 구조 리팩토링
- [ ] 기타

## 반영 브랜치

> Lck_Refactor -> develop

## 작업 상세 내용

- 반응형때 중앙이 안맞거나 선수정보 카드가 겹치는 현상이 있어서 수정했습니다.


## 결과물
![스크린샷 2023-01-31 오후 6 51 30](https://user-images.githubusercontent.com/92585734/215726753-6abb2d3c-d4e9-42ab-9968-51ffd33525c3.png)

